### PR TITLE
Update h3 to 4.2.1

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,8 +8,10 @@ on:
     branches: [master]
 
 jobs:
-  build:
+  build_with_prebuild_h3:
     runs-on: ubuntu-latest
+    env:
+      H3_INSTALL_PREFIX: ${{ github.workspace }}/h3_inst
     steps:
       - uses: actions/checkout@v2
       - name: Install h3 build deps
@@ -21,11 +23,29 @@ jobs:
           path: h3
           ref: v4.2.1
       - name: Generate build folder for uber/h3
-        run: cmake -S h3 -B h3_build
+        run: cmake -S h3 -B h3_build -DCMAKE_BUILD_TYPE=Release
       - name: Build uber/h3
         run: cmake --build h3_build --parallel 8
       - name: Install uber/h3
-        run: cmake --install ./h3_build --prefix $HOME/.local
+        run: cmake --install ./h3_build --prefix $H3_INSTALL_PREFIX
+      - name: Build libh3
+        run: cargo build --verbose --no-default-features
+      - name: Test libh3
+        run: cargo test --verbose --no-default-features
+
+  build_from_scratch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build libh3
+        run: cargo build --verbose
+      - name: Test libh3
+        run: cargo test --verbose
+
+  build_win_from_scratch:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
       - name: Build libh3
         run: cargo build --verbose
       - name: Test libh3

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,7 @@
 name: Rust
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [master]
   pull_request:
@@ -9,7 +10,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
       - name: Install h3 build deps
@@ -19,11 +19,14 @@ jobs:
         with:
           repository: uber/h3
           path: h3
-      - name: Build H3
-        run: cd h3 && cmake . && make -j
-      - name: Install H3
-        run: cd h3 && sudo make install
-      - name: Build Rust
+          ref: v4.2.1
+      - name: Generate build folder for uber/h3
+        run: cmake -S h3 -B h3_build
+      - name: Build uber/h3
+        run: cmake --build h3_build --parallel 8
+      - name: Install uber/h3
+        run: cmake --install ./h3_build --prefix $HOME/.local
+      - name: Build libh3
         run: cargo build --verbose
-      - name: Run tests
+      - name: Test libh3
         run: cargo test --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
-/target
+.vscode
+target
 Cargo.lock
+src/libh3_sys.rs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,38 @@
 [package]
 name = "libh3"
-version = "0.2.0"
-authors = ["Rusty Conover <rusty@conover.me>"]
+version = "0.2.1"
+authors = ["Rusty Conover <rusty@conover.me>", "Ricky <ricky85ps@web.de>"]
 edition = "2018"
 license = "MIT"
-repository = "https://github.com/rustyconover/libh3.git"
+repository = "https://github.com/ricky85ps/libh3.git"
 description = "Safe Rust Bindings to Uber's Hexagonal Hierarchical Spatial Index - H3"
 
 [build-dependencies]
-bindgen = "0.71.1"
-directories = "6.0.0"
+bindgen = { version = "0.71.1" }
+cmake = { version = "0.1.54", optional = true }
+flate2 = { version = "1.1.1", optional = true }
+hex = { version = "0.4.3", optional = true }
+reqwest = { version = "0.12.15", features = ["blocking"], optional = true }
+sha2 = { version = "0.10.8", optional = true }
+tar = { version = "0.4.44", optional = true }
+toml = { version = "0.8.20", optional = true }
 
 [dependencies]
 static_assertions = "1.1.0"
+
+[package.metadata.h3-sources]
+targz_url = "https://github.com/uber/h3/archive/refs/tags/v4.2.1.tar.gz"
+targz_sha512sum = "1d04644d8e5b6d1a9a741e6289ef65ca3dfe7c9e26b1f70d9e59a37d1e8fc1e686e27d5f6464efafca4a83755dbec9f755ee9dc11c88610cdd618c933d32d27d"
+targz_root_dir = "h3-4.2.1"
+
+[features]
+default = ["uber_h3_from_scratch"]
+uber_h3_from_scratch = [
+    "dep:cmake",
+    "dep:flate2",
+    "dep:hex",
+    "dep:reqwest",
+    "dep:sha2",
+    "dep:tar",
+    "dep:toml",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,15 @@
 [package]
 name = "libh3"
-version = "0.1.8"
+version = "0.2.0"
 authors = ["Rusty Conover <rusty@conover.me>"]
 edition = "2018"
 license = "MIT"
 repository = "https://github.com/rustyconover/libh3.git"
 description = "Safe Rust Bindings to Uber's Hexagonal Hierarchical Spatial Index - H3"
 
+[build-dependencies]
+bindgen = "0.71.1"
+directories = "6.0.0"
+
 [dependencies]
-libh3-sys = "0.1.3"
-float-cmp = "0.6.0"
+static_assertions = "1.1.0"

--- a/Readme.md
+++ b/Readme.md
@@ -8,20 +8,46 @@ Contributions are welcome, just do a pull request.
 ## Quickstart
 
 This refers to a Debian like sytem, please adopt to your needs.
-You need [Uber's H3 library](https://github.com/uber/h3) to be installed,
+It will build [Uber's H3 library](https://github.com/uber/h3) during build step,
 otherwise the libh3 crate cannot link.
-To get a version which fits do following steps.
-`--prefix $HOME/.local` is where the crate searches for, when building
+
+```bash
+sudo apt install cmake make gcc libtool
+```
+
+You may then dir into your project and build it using libh3 as dependency
+
+## Provide Own H3 Library
+
+To provide your own H3 Library, you must set `H3_INSTALL_PREFIX` as environment variable, so
+libh3 can find it's header and static library.
+You must then call cargo with feature flag `uber_h3_from_scratch` **disabled**, e.g.:
+
+```bash
+cargo build --no-default-features
+```
+
+### Provided By Distribution
+
+If you installed H3 via a package manager, it's likely installed to `/usr`.
+Set environment accordingly:
+
+```bash
+export H3_INSTALL_PREFIX=/usr
+```
+
+### Self build
+
+To build from sources do following steps:
 
 ```bash
 sudo apt install git cmake make gcc libtool
 git clone --depth=1 --branch v4.2.1 https://github.com/uber/h3.git
+export H3_INSTALL_PREFIX=$PWD/h3_inst
 cmake -S h3 -B h3_build
 cmake --build h3_build --parallel 8
-cmake --install ./h3_build --prefix $HOME/.local
+cmake --install ./h3_build --prefix $H3_INSTALL_PREFIX
 ```
-
-You may then dir into your project and build it using libh3 as dependency
 
 ## Documentation
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,9 +1,31 @@
 # libh3 - Wrapper for Uber’s H3 Hexagonal Hierarchical Spatial Index in Rust
 
-This crate calls functions provided by [libh3-sys](https://docs.rs/libh3-sys/) to expose a safe Rust API for the H3 library.
+This crate calls functions provided by [Uber's H3 library](https://github.com/uber/h3)
+to expose a safe Rust API for it.
 
-Contributions are welcome.
+Contributions are welcome, just do a pull request.
 
-See the documentation here:
+## Quickstart
 
-[https://docs.rs/libh3/](https://docs.rs/libh3/)
+This refers to a Debian like sytem, please adopt to your needs.
+You need [Uber's H3 library](https://github.com/uber/h3) to be installed,
+otherwise the libh3 crate cannot link.
+To get a version which fits do following steps.
+`--prefix $HOME/.local` is where the crate searches for, when building
+
+```bash
+sudo apt install git cmake make gcc libtool
+git clone --depth=1 --branch v4.2.1 https://github.com/uber/h3.git
+cmake -S h3 -B h3_build
+cmake --build h3_build --parallel 8
+cmake --install ./h3_build --prefix $HOME/.local
+```
+
+You may then dir into your project and build it using libh3 as dependency
+
+## Documentation
+
+For further documentation have a look at [https://docs.rs/libh3/](https://docs.rs/libh3/)
+
+For the concepts behind the library refer to [h3geo.org](https://h3geo.org) or
+[the H3 blog](https://www.uber.com/en-DE/blog/h3/)

--- a/build.rs
+++ b/build.rs
@@ -1,33 +1,133 @@
-use directories::UserDirs;
+#[cfg(feature = "uber_h3_from_scratch")]
+mod uber_h3_from_scratch {
+    use sha2::Digest;
+    use std::path::{Path, PathBuf};
+    fn download(url: &str, dest: &str, sha512: &str) {
+        println!("{url} -> {dest}");
+        let file_content = reqwest::blocking::get(url)
+            .expect("Download failed")
+            .bytes()
+            .expect("Decoding failed");
 
-fn main() {
-    let ud = UserDirs::new().unwrap();
-    let home = ud.home_dir();
-    let header_file = home
-        .join(".local/include/h3/h3api.h")
-        .into_os_string()
-        .into_string()
-        .unwrap();
-    let lib_path = home
-        .join(".local/lib")
-        .into_os_string()
-        .into_string()
-        .unwrap();
-    println!("cargo:rustc-link-search={lib_path}");
-    println!("cargo:rustc-link-lib=h3");
+        let mut hasher = sha2::Sha512::new();
+        hasher.update(&file_content);
+        let checksum = hasher.finalize();
+        let sha512 = hex::decode(sha512).expect("Checksum not valid HEX!");
+        if &checksum[..] != &sha512[..] {
+            panic!(
+                "Checksum for {} invalid {:?} != {:?}",
+                dest,
+                checksum.to_vec(),
+                sha512
+            )
+        }
+
+        let mut file = std::fs::File::create(dest).expect("archive could not be created");
+        let mut content = std::io::Cursor::new(file_content);
+        std::io::copy(&mut content, &mut file).expect("File couldn't be written");
+    }
+
+    fn untar(targz: &str, dest: &str) {
+        let tar_gz = std::fs::File::open(targz).expect("Archive not found!");
+        let tar = flate2::read::GzDecoder::new(tar_gz);
+        let mut archive = tar::Archive::new(tar);
+        archive.unpack(dest).expect("Unpacking failed");
+    }
+
+    struct H3Sources {
+        targz_url: String,
+        targz_sha512sum: String,
+        targz_root_dir: String,
+    }
+
+    fn from_toml(toml: &str) -> H3Sources {
+        let contents: String = std::fs::read_to_string(toml).expect("File missing: {toml}");
+        let table = contents.parse::<toml::Table>().unwrap();
+
+        let h3_sources = table["package"].as_table().expect("Read package failed")["metadata"]
+            .as_table()
+            .expect("Read metadata failed!")["h3-sources"]
+            .as_table()
+            .expect("Read h3-sources failed!");
+
+        let targz_url = h3_sources["targz_url"]
+            .as_str()
+            .expect("targz_url missing!")
+            .to_string();
+
+        let targz_sha512sum = h3_sources["targz_sha512sum"]
+            .as_str()
+            .expect("targz_sha512sum missing!")
+            .to_string();
+        let targz_root_dir = h3_sources["targz_root_dir"]
+            .as_str()
+            .expect("targz_root_dir missing!")
+            .to_string();
+
+        H3Sources {
+            targz_url,
+            targz_sha512sum,
+            targz_root_dir,
+        }
+    }
+
+    pub fn build() -> Result<PathBuf, Box<dyn std::error::Error>> {
+        let out_dir = std::env::var("OUT_DIR")?;
+        let out_dir = Path::new(&out_dir);
+        let src_dir = out_dir.join("uber");
+
+        let info = from_toml("Cargo.toml");
+        let targz_name = Path::new(&info.targz_url).iter().last().unwrap();
+
+        std::fs::create_dir_all(&src_dir)?;
+        let dwnld_dest = out_dir.join(targz_name);
+        if !dwnld_dest.exists() {
+            download(
+                &info.targz_url,
+                &dwnld_dest.display().to_string(),
+                &info.targz_sha512sum,
+            );
+        }
+        untar(dwnld_dest.to_str().unwrap(), src_dir.to_str().unwrap());
+
+        let dst = cmake::Config::new(src_dir.join(info.targz_root_dir))
+            .profile("Release")
+            .build();
+        Ok(dst)
+    }
+}
+
+#[cfg(not(feature = "uber_h3_from_scratch"))]
+fn from_env() -> std::path::PathBuf {
+    let h3_inst_prefix = std::env::var("H3_INSTALL_PREFIX")
+        .expect("Environment variable H3_INSTALL_PREFIX must be set");
+    std::path::Path::new(&h3_inst_prefix).to_owned()
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(not(feature = "uber_h3_from_scratch"))]
+    let h3_inst_prefix = from_env();
+
+    #[cfg(feature = "uber_h3_from_scratch")]
+    let h3_inst_prefix = uber_h3_from_scratch::build()?;
+
+    let header_file = h3_inst_prefix
+        .join("include/h3/h3api.h")
+        .display()
+        .to_string();
+    println!(
+        "cargo:rustc-link-search=native={}",
+        h3_inst_prefix.join("lib").display()
+    );
+    println!("cargo:rustc-link-lib=static=h3");
     let bindings = bindgen::Builder::default()
-        // The input header we would like to generate
-        // bindings for.
         .header(header_file)
-        // Tell cargo to invalidate the built crate whenever any of the
-        // included header files changed.
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
-        // Finish the builder and generate the bindings.
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new())) // invalidate the built crate when header file changed
         .generate()
-        // Unwrap the Result and panic on failure.
         .expect("Unable to generate bindings");
 
     bindings
         .write_to_file("src/libh3_sys.rs")
         .expect("Couldn't write bindings!");
+    Ok(())
 }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,33 @@
+use directories::UserDirs;
+
+fn main() {
+    let ud = UserDirs::new().unwrap();
+    let home = ud.home_dir();
+    let header_file = home
+        .join(".local/include/h3/h3api.h")
+        .into_os_string()
+        .into_string()
+        .unwrap();
+    let lib_path = home
+        .join(".local/lib")
+        .into_os_string()
+        .into_string()
+        .unwrap();
+    println!("cargo:rustc-link-search={lib_path}");
+    println!("cargo:rustc-link-lib=h3");
+    let bindings = bindgen::Builder::default()
+        // The input header we would like to generate
+        // bindings for.
+        .header(header_file)
+        // Tell cargo to invalidate the built crate whenever any of the
+        // included header files changed.
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+        // Finish the builder and generate the bindings.
+        .generate()
+        // Unwrap the Result and panic on failure.
+        .expect("Unable to generate bindings");
+
+    bindings
+        .write_to_file("src/libh3_sys.rs")
+        .expect("Couldn't write bindings!");
+}

--- a/contributing.md
+++ b/contributing.md
@@ -1,4 +1,4 @@
-## It is great you'd like to contribute!
+# It is great you'd like to contribute
 
 First, thank you!
 

--- a/contributing.md
+++ b/contributing.md
@@ -5,6 +5,6 @@ First, thank you!
 To contribute changes please just open pull requests against the
 repository at:
 
-[https://github.com/rustyconover/libh3](https://github.com/rustyconover/libh3)
+[https://github.com/ricky85ps/libh3](https://github.com/ricky85ps/libh3)
 
 Please use the issue tracker there as well.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,63 @@
+extern crate static_assertions;
+
+mod libh3_sys {
+    #![allow(improper_ctypes)]
+    #![allow(unused)]
+    #![allow(non_upper_case_globals)]
+    #![allow(non_camel_case_types)]
+    #![allow(non_snake_case)]
+    include!("libh3_sys.rs");
+}
+use std::convert::From;
 use std::mem::MaybeUninit;
+
+static_assertions::const_assert_eq!(libh3_sys::H3_VERSION_MAJOR, 4);
+static_assertions::const_assert!(libh3_sys::H3_VERSION_MINOR >= 2);
+
+#[derive(Debug)]
+pub enum H3Err {
+    Success = 0,      // Success (no error)
+    Failed,           // The operation failed but a more specific error is not available
+    Domain, // Argument was outside of acceptable range (when a more specific error code is not available)
+    LatLngDomain, // Latitude or longitude arguments were outside of acceptable range
+    ResDomain, // Resolution argument was outside of acceptable range
+    CellInvalid, // `H3Index` cell argument was not valid
+    DirEdgeInvalid, // `H3Index` directed edge argument was not valid
+    UndirEdgeInvalid, // `H3Index` undirected edge argument was not valid
+    VertexInvalid, // `H3Index` vertex argument was not valid
+    Pentagon, // Pentagon distortion was encountered which the algorithm could not handle it
+    DuplicateInput, // Duplicate input was encountered in the arguments and the algorithm could not handle it
+    NotNeighbors,   // `H3Index` cell arguments were not neighbors
+    ResMismatch,    // `H3Index` cell arguments had incompatible resolutions
+    MemoryAlloc,    // Necessary memory allocation failed
+    MemoryBounds,   // Bounds of provided memory were not large enough
+    OptionInvalid,  // Mode or flags argument was not valid.
+    InvalidErrCode, // H3ErrorCodes from libh3 is invalid
+}
+
+impl From<libh3_sys::H3ErrorCodes> for H3Err {
+    fn from(value: libh3_sys::H3ErrorCodes) -> Self {
+        match value {
+            0 => H3Err::Success,
+            1 => H3Err::Failed,
+            2 => H3Err::Domain,
+            3 => H3Err::LatLngDomain,
+            4 => H3Err::ResDomain,
+            5 => H3Err::CellInvalid,
+            6 => H3Err::DirEdgeInvalid,
+            7 => H3Err::UndirEdgeInvalid,
+            8 => H3Err::VertexInvalid,
+            9 => H3Err::Pentagon,
+            10 => H3Err::DuplicateInput,
+            11 => H3Err::NotNeighbors,
+            12 => H3Err::ResMismatch,
+            13 => H3Err::MemoryAlloc,
+            14 => H3Err::MemoryBounds,
+            15 => H3Err::OptionInvalid,
+            _else => H3Err::InvalidErrCode,
+        }
+    }
+}
 
 /// Convert degrees to radians
 ///
@@ -26,9 +85,9 @@ pub struct GeoCoord {
     // The latitute of the coordinate, typcially this should be specified using
     // radians but it is easy to convert using [degs_to_rads](degs_to_rads)
     pub lat: f64,
-    // The longitude of the coordinate, typcially this should be specified using
+    // The longgitude of the coordinate, typcially this should be specified using
     // radians but it is easy to convert using [degs_to_rads](degs_to_rads)
-    pub lon: f64,
+    pub lng: f64,
 }
 
 impl GeoCoord {
@@ -37,18 +96,27 @@ impl GeoCoord {
     /// # Arguments
     ///
     /// * `lat` - The latitude of the coordinate
-    /// * `long` - The longitude of the coordinate
+    /// * `lng` - The longgitude of the coordinate
     ///
-    pub fn new(lat: f64, lon: f64) -> GeoCoord {
-        GeoCoord { lat, lon }
+    pub fn new(lat: f64, lng: f64) -> GeoCoord {
+        GeoCoord { lat, lng }
     }
 }
 
-impl From<&GeoCoord> for libh3_sys::GeoCoord {
-    fn from(coord: &GeoCoord) -> Self {
-        libh3_sys::GeoCoord {
+impl From<libh3_sys::LatLng> for GeoCoord {
+    fn from(coord: libh3_sys::LatLng) -> Self {
+        GeoCoord {
             lat: coord.lat,
-            lon: coord.lon,
+            lng: coord.lng,
+        }
+    }
+}
+
+impl From<&GeoCoord> for libh3_sys::LatLng {
+    fn from(coord: &GeoCoord) -> Self {
+        libh3_sys::LatLng {
+            lat: coord.lat,
+            lng: coord.lng,
         }
     }
 }
@@ -67,30 +135,53 @@ pub type Resolution = u8;
 ///
 /// ```
 /// use libh3::edge_length_km;
-/// assert_eq!(edge_length_km(5), 8.544408276);
+/// assert_eq!(edge_length_km(5)?, 9.85409099);
+/// # Ok::<(), libh3::H3Err>(())
 /// ```
-pub fn edge_length_km(resolution: Resolution) -> f64 {
-    unsafe { libh3_sys::edgeLengthKm(resolution as i32) }
+pub fn edge_length_km(resolution: Resolution) -> Result<f64, H3Err> {
+    let mut out = 0f64;
+    match unsafe {
+        libh3_sys::getHexagonEdgeLengthAvgKm(resolution as ::std::os::raw::c_int, &mut out)
+    }
+    .into()
+    {
+        H3Err::Success => Ok(out),
+        error => Err(error),
+    }
 }
 
 /// Return the number of hexagons at a particular resolution.
 ///
 /// ```
-/// use libh3::num_hexagons;
-/// assert_eq!(num_hexagons(5), 2016842);
+/// use libh3::num_cells;
+/// assert_eq!(num_cells(5)?, 2016842);
+/// # Ok::<(), libh3::H3Err>(())
 /// ```
-pub fn num_hexagons(resolution: Resolution) -> u64 {
-    unsafe { libh3_sys::numHexagons(resolution as i32) as u64 }
+pub fn num_cells(resolution: Resolution) -> Result<i64, H3Err> {
+    let mut out = 0i64;
+    match unsafe { libh3_sys::getNumCells(resolution as ::std::os::raw::c_int, &mut out) }.into() {
+        H3Err::Success => Ok(out),
+        error => Err(error),
+    }
 }
 
 /// Return the edge length of a hexagon at a particular resolution in meters.
 ///
 /// ```
 /// use libh3::edge_length_m;
-/// assert_eq!(edge_length_m(5), 8544.408276);
+/// assert_eq!(edge_length_m(5)?, 9854.09099);
+/// # Ok::<(), libh3::H3Err>(())
 /// ```
-pub fn edge_length_m(resolution: Resolution) -> f64 {
-    unsafe { libh3_sys::edgeLengthM(resolution as i32) }
+pub fn edge_length_m(resolution: Resolution) -> Result<f64, H3Err> {
+    let mut out = 0f64;
+    match unsafe {
+        libh3_sys::getHexagonEdgeLengthAvgM(resolution as ::std::os::raw::c_int, &mut out)
+    }
+    .into()
+    {
+        H3Err::Success => Ok(out),
+        error => Err(error),
+    }
 }
 
 /// Convert a GeoCoord to a H3 index.
@@ -99,18 +190,22 @@ pub fn edge_length_m(resolution: Resolution) -> f64 {
 /// use libh3::{GeoCoord, degs_to_rads, geo_to_h3};
 /// let coords = GeoCoord {
 ///   lat: degs_to_rads(40.689167),
-///   lon: degs_to_rads(-74.044444),
+///   lng: degs_to_rads(-74.044444),
 /// };
 ///
 /// let v = geo_to_h3(&coords, 10);
-/// assert_eq!(v.unwrap(), 0x8a2a1072b59ffff);
+/// assert_eq!(v?, 0x8a2a1072b59ffff);
+/// # Ok::<(), libh3::H3Err>(())
 /// ```
-pub fn geo_to_h3(coord: &GeoCoord, resolution: Resolution) -> Result<H3Index, ()> {
-    unsafe {
-        match libh3_sys::geoToH3(&libh3_sys::GeoCoord::from(coord), resolution as i32) {
-            0 => Err(()),
-            x => Ok(x),
-        }
+pub fn geo_to_h3(coord: &GeoCoord, resolution: Resolution) -> Result<H3Index, H3Err> {
+    let mut out = 0u64;
+    match unsafe {
+        libh3_sys::latLngToCell(&coord.into(), resolution as ::std::os::raw::c_int, &mut out)
+    }
+    .into()
+    {
+        H3Err::Success => Ok(out),
+        error => Err(error),
     }
 }
 
@@ -118,41 +213,59 @@ pub fn geo_to_h3(coord: &GeoCoord, resolution: Resolution) -> Result<H3Index, ()
 ///
 /// ```
 /// use libh3::h3_to_geo;
-/// let r = h3_to_geo(0x8a2a1072b59ffff);
-/// assert_eq!(r.lat, 0.7101643819054542);
-/// assert_eq!(r.lon, -1.2923191206954798);
+/// let r = h3_to_geo(0x8a2a1072b59ffff)?;
+/// assert_eq!(r.lat, 0.710164381905454);
+/// assert_eq!(r.lng, -1.2923191206954798);
+/// # Ok::<(), libh3::H3Err>(())
 /// ```
-pub fn h3_to_geo(h3: H3Index) -> GeoCoord {
-    let result = unsafe {
-        let mut result: MaybeUninit<libh3_sys::GeoCoord> = MaybeUninit::uninit().assume_init();
-        libh3_sys::h3ToGeo(h3, result.as_mut_ptr());
-        result.assume_init()
+pub fn h3_to_geo(h3: H3Index) -> Result<GeoCoord, H3Err> {
+    let mut out = libh3_sys::LatLng {
+        lat: 0f64,
+        lng: 0f64,
     };
-    GeoCoord::new(result.lat, result.lon)
+    match unsafe { libh3_sys::cellToLatLng(h3, &mut out) }.into() {
+        H3Err::Success => Ok(out.into()),
+        error => Err(error),
+    }
 }
 
-type GeoBoundary = Vec<GeoCoord>;
+pub struct CellBoundary {
+    pub vec: Vec<GeoCoord>,
+}
+
+impl From<libh3_sys::CellBoundary> for CellBoundary {
+    fn from(value: libh3_sys::CellBoundary) -> Self {
+        let mut cellboundary = CellBoundary { vec: Vec::new() };
+        for i in 0..value.numVerts as usize {
+            cellboundary.vec.push(value.verts[i].into());
+        }
+        cellboundary
+    }
+}
 
 /// Convert a H3 index value to a GeoBoundary which are a
 /// vector of points that describe a H3 Index's boundary
 ///
 /// ```
 /// use libh3::h3_to_geo_boundary;
-/// let foo = h3_to_geo_boundary(0x8a2a1072b59ffff);
-/// assert_eq!(foo.len(), 6);
+/// let foo = h3_to_geo_boundary(0x8a2a1072b59ffff)?;
+/// assert_eq!(foo.vec.len(), 6);
+/// # Ok::<(), libh3::H3Err>(())
 /// ```
-pub fn h3_to_geo_boundary(h3: H3Index) -> GeoBoundary {
-    unsafe {
-        let mut boundary_result: MaybeUninit<libh3_sys::GeoBoundary> =
-            MaybeUninit::uninit().assume_init();
-        libh3_sys::h3ToGeoBoundary(h3, boundary_result.as_mut_ptr());
-        let boundary = boundary_result.assume_init();
-        let mut result = Vec::with_capacity(boundary.numVerts as usize);
-        for i in 0..boundary.numVerts as usize {
-            result.push(GeoCoord::new(boundary.verts[i].lat, boundary.verts[i].lon));
-        }
-        result
+pub fn h3_to_geo_boundary(h3: H3Index) -> Result<CellBoundary, H3Err> {
+    let mut boundary_result: MaybeUninit<libh3_sys::CellBoundary> =
+        unsafe { MaybeUninit::uninit().assume_init() };
+
+    match unsafe { libh3_sys::cellToBoundary(h3, boundary_result.as_mut_ptr()) }.into() {
+        H3Err::Success => {}
+        error => return Err(error),
     }
+    let boundary = unsafe { boundary_result.assume_init() };
+    let mut result = Vec::with_capacity(boundary.numVerts as usize);
+    for i in 0..boundary.numVerts as usize {
+        result.push(GeoCoord::new(boundary.verts[i].lat, boundary.verts[i].lng));
+    }
+    Ok(CellBoundary { vec: result })
 }
 
 /// Return the resolution of a H3 index
@@ -166,9 +279,17 @@ pub fn h3_to_geo_boundary(h3: H3Index) -> GeoBoundary {
 ///
 /// let v = geo_to_h3(&coords, 10);
 /// assert_eq!(h3_get_resolution(v.unwrap()), 10);
+/// # Ok::<(), libh3::H3Err>(())
 /// ````
 pub fn h3_get_resolution(h3: H3Index) -> Resolution {
-    unsafe { libh3_sys::h3GetResolution(h3) as Resolution }
+    unsafe { libh3_sys::getResolution(h3) as Resolution }
+}
+
+fn to_bool(from: ::std::os::raw::c_int) -> bool {
+    match from {
+        0 => false,
+        _else => true,
+    }
 }
 
 /// Determine if H3 index is valid
@@ -177,19 +298,15 @@ pub fn h3_get_resolution(h3: H3Index) -> Resolution {
 /// use libh3::{GeoCoord, degs_to_rads, geo_to_h3, h3_is_valid};
 /// let coords = GeoCoord {
 ///   lat: degs_to_rads(40.689167),
-///   lon: degs_to_rads(-74.044444),
+///   lng: degs_to_rads(-74.044444),
 /// };
 ///
 /// let v = geo_to_h3(&coords, 10);
 /// assert_eq!(h3_is_valid(v.unwrap()),true);
+/// # Ok::<(), libh3::H3Err>(())
 /// ```
 pub fn h3_is_valid(h3: H3Index) -> bool {
-    unsafe {
-        match libh3_sys::h3IsValid(h3) {
-            0 => false,
-            _ => true,
-        }
-    }
+    to_bool(unsafe { libh3_sys::isValidCell(h3) })
 }
 
 /// Determine if two H3 indexes are neighbors
@@ -198,18 +315,18 @@ pub fn h3_is_valid(h3: H3Index) -> bool {
 /// use libh3::{GeoCoord, degs_to_rads, geo_to_h3, h3_indexes_are_neighbors};
 /// let coords = GeoCoord {
 ///   lat: degs_to_rads(40.689167),
-///   lon: degs_to_rads(-74.044444),
+///   lng: degs_to_rads(-74.044444),
 /// };
 ///
-/// let v = geo_to_h3(&coords, 10);
-/// assert_eq!(h3_indexes_are_neighbors(v.unwrap(), v.unwrap()), false);
+/// let v = geo_to_h3(&coords, 10)?;
+/// assert_eq!(h3_indexes_are_neighbors(v, v)?, false);
+/// # Ok::<(), libh3::H3Err>(())
 /// ```
-pub fn h3_indexes_are_neighbors(origin: H3Index, destination: H3Index) -> bool {
-    unsafe {
-        match libh3_sys::h3IndexesAreNeighbors(origin, destination) {
-            0 => false,
-            _ => true,
-        }
+pub fn h3_indexes_are_neighbors(origin: H3Index, destination: H3Index) -> Result<bool, H3Err> {
+    let mut out: ::std::os::raw::c_int = 0;
+    match unsafe { libh3_sys::areNeighborCells(origin, destination, &mut out) }.into() {
+        H3Err::Success => Ok(to_bool(out)),
+        error => Err(error),
     }
 }
 
@@ -217,23 +334,26 @@ pub fn h3_indexes_are_neighbors(origin: H3Index, destination: H3Index) -> bool {
 ///
 /// ```
 /// use libh3::{ hex_area_km_2};
-/// assert_eq!(hex_area_km_2(10), 0.0150475);
+/// assert_eq!(hex_area_km_2(10)?, 0.01504750190766435);
+/// # Ok::<(), libh3::H3Err>(())
 /// ```
-pub fn hex_area_km_2(resolution: i32) -> f64 {
-    unsafe { libh3_sys::hexAreaKm2(resolution) }
+pub fn hex_area_km_2(resolution: i32) -> Result<f64, H3Err> {
+    let mut out = 0f64;
+    match unsafe { libh3_sys::getHexagonAreaAvgKm2(resolution as ::std::os::raw::c_int, &mut out) }
+        .into()
+    {
+        H3Err::Success => Ok(out),
+        error => Err(error),
+    }
 }
 
 /// Determine if the specified H3 index is a pentagon.
 /// ```
 /// assert_eq!(libh3::h3_is_pentagon(0x8a2a1072b59ffff), false);
+/// # Ok::<(), libh3::H3Err>(())
 /// ```
 pub fn h3_is_pentagon(h3: H3Index) -> bool {
-    unsafe {
-        match libh3_sys::h3IsPentagon(h3) {
-            0 => false,
-            _ => true,
-        }
-    }
+    to_bool(unsafe { libh3_sys::isPentagon(h3) })
 }
 
 /// Get the number of the base cell for a given H3 index
@@ -241,10 +361,13 @@ pub fn h3_is_pentagon(h3: H3Index) -> bool {
 /// ```
 /// use libh3;
 /// assert_eq!(libh3::h3_get_base_cell(0x8a2a1072b59ffff), 21);
+/// # Ok::<(), libh3::H3Err>(())
 /// ```
 pub fn h3_get_base_cell(h3: H3Index) -> i32 {
-    unsafe { libh3_sys::h3GetBaseCell(h3) }
+    unsafe { libh3_sys::getBaseCellNumber(h3) }
 }
+
+pub type HexDistance = i32;
 
 /// Get all hexagons in a k-ring around a given center. The order of the hexagons is undefined.
 ///
@@ -263,18 +386,26 @@ pub fn h3_get_base_cell(h3: H3Index) -> i32 {
 ///   0x8a2a1072b58ffff,
 ///   0x8a2a1072b587fff,
 /// ];
-/// let r = libh3::k_ring(0x8a2a1072b59ffff, 1);
+/// let r = libh3::k_ring(0x8a2a1072b59ffff, 1)?;
 /// assert_eq!(r, expected_kring);
+/// # Ok::<(), libh3::H3Err>(())
 /// ```
-pub fn k_ring(origin: H3Index, radius: i32) -> Vec<H3Index> {
-    unsafe {
-        let max = libh3_sys::maxKringSize(radius);
-        let mut r = Vec::<H3Index>::with_capacity(max as usize);
-        libh3_sys::kRing(origin, radius, r.as_mut_ptr());
-        r.set_len(max as usize);
-        r = r.into_iter().filter(|v| *v != 0).collect();
-        r
+pub fn k_ring(origin: H3Index, radius: HexDistance) -> Result<Vec<H3Index>, H3Err> {
+    let mut max = 0;
+    match unsafe { libh3_sys::maxGridDiskSize(radius, &mut max) }.into() {
+        H3Err::Success => {}
+        error => return Err(error),
     }
+
+    let mut r = Vec::<H3Index>::with_capacity(max as usize);
+    match unsafe { libh3_sys::gridDisk(origin, radius, r.as_mut_ptr()) }.into() {
+        H3Err::Success => {}
+        error => return Err(error),
+    }
+
+    unsafe { r.set_len(max as usize) };
+    r = r.into_iter().filter(|v| *v != 0).collect();
+    Ok(r)
 }
 
 /// Get all hexagons in a k-ring around a given center, in an array of arrays
@@ -295,58 +426,106 @@ pub fn k_ring(origin: H3Index, radius: i32) -> Vec<H3Index> {
 ///   (0x8a2a1072b58ffff, 1),
 ///   (0x8a2a1072b587fff, 1),
 /// ];
-/// let r = libh3::k_ring_distances(0x8a2a1072b59ffff, 1);
+/// let r = libh3::k_ring_distances(0x8a2a1072b59ffff, 1)?;
 /// assert_eq!(r, expected_kring_distances);
+/// # Ok::<(), libh3::H3Err>(())
 /// ```
-pub fn k_ring_distances(origin: H3Index, radius: i32) -> Vec<(H3Index, i32)> {
-    unsafe {
-        let max = libh3_sys::maxKringSize(radius);
-        let mut indexes = Vec::<H3Index>::with_capacity(max as usize);
-        let mut distances = Vec::<i32>::with_capacity(max as usize);
-
-        libh3_sys::kRingDistances(origin, radius, indexes.as_mut_ptr(), distances.as_mut_ptr());
-        indexes.set_len(max as usize);
-        distances.set_len(max as usize);
-
-        indexes
-            .into_iter()
-            .zip(distances.into_iter())
-            .filter(|v| v.0 != 0)
-            .collect::<Vec<(H3Index, i32)>>()
+pub fn k_ring_distances(
+    origin: H3Index,
+    radius: HexDistance,
+) -> Result<Vec<(H3Index, HexDistance)>, H3Err> {
+    let mut max = 0i64;
+    match unsafe { libh3_sys::maxGridDiskSize(radius, &mut max) }.into() {
+        H3Err::Success => {}
+        error => return Err(error),
     }
+
+    let mut indexes = Vec::<H3Index>::with_capacity(max as usize);
+    let mut distances = Vec::<HexDistance>::with_capacity(max as usize);
+
+    match unsafe {
+        libh3_sys::gridDiskDistances(origin, radius, indexes.as_mut_ptr(), distances.as_mut_ptr())
+    }
+    .into()
+    {
+        H3Err::Success => {}
+        error => return Err(error),
+    }
+    unsafe { indexes.set_len(max as usize) };
+    unsafe { distances.set_len(max as usize) };
+
+    Ok(indexes
+        .into_iter()
+        .zip(distances.into_iter())
+        .filter(|v| v.0 != 0)
+        .collect::<Vec<(H3Index, HexDistance)>>())
 }
 
-pub fn hex_range(origin: H3Index, k: i32) -> (bool, Vec<H3Index>) {
-    unsafe {
-        let max = libh3_sys::maxKringSize(k);
-        let mut r = Vec::<H3Index>::with_capacity(max as usize);
-        let distortion = libh3_sys::hexRange(origin, k, r.as_mut_ptr());
-        r.set_len(max as usize);
-        r = r.into_iter().filter(|v| *v != 0).collect();
-        (distortion == 0, r)
+/// Produce indexes within k distance of the origin index.
+/// Output behavior is undefined when one of the indexes returned by this
+/// function is a pentagon or is in the pentagon distortion area, H3Err::Pentagon
+/// will be returned then
+///
+/// # Arguments
+///
+/// * `origin` - The center of the ring.
+/// * `k_ring` - 0 is defined as the origin index, k-ring 1 is defined as k-ring 0 and
+///   all neighboring indexes, and so on.
+///
+/// Output is placed in the provided array in order of increasing distance from
+/// the origin.
+pub fn hex_range(origin: H3Index, k_ring: HexDistance) -> Result<Vec<H3Index>, H3Err> {
+    let mut max = 0i64;
+    match unsafe { libh3_sys::maxGridDiskSize(k_ring, &mut max) }.into() {
+        H3Err::Success => {}
+        error => return Err(error),
     }
+    let mut r = Vec::<H3Index>::with_capacity(max as usize);
+    match unsafe { libh3_sys::gridDiskUnsafe(origin, k_ring, r.as_mut_ptr()) }.into() {
+        H3Err::Success => {}
+        error => return Err(error),
+    }
+    unsafe { r.set_len(max as usize) };
+    r = r.into_iter().filter(|v| *v != 0).collect();
+    Ok(r)
 }
 
-pub fn hex_range_distances(origin: H3Index, k: i32) -> (bool, Vec<(H3Index, i32)>) {
-    unsafe {
-        let max = libh3_sys::maxKringSize(k);
-        let mut indexes = Vec::<H3Index>::with_capacity(max as usize);
-        let mut distances = Vec::<i32>::with_capacity(max as usize);
+/// Does the same as hex_range(), but also provides the distance as second value of the
+/// returned vector
+pub fn hex_range_distances(
+    origin: H3Index,
+    k_ring: HexDistance,
+) -> Result<Vec<(H3Index, HexDistance)>, H3Err> {
+    let mut max = 0i64;
+    match unsafe { libh3_sys::maxGridDiskSize(k_ring, &mut max) }.into() {
+        H3Err::Success => {}
+        error => return Err(error),
+    }
 
-        let distortion =
-            libh3_sys::hexRangeDistances(origin, k, indexes.as_mut_ptr(), distances.as_mut_ptr());
-        indexes.set_len(max as usize);
-        distances.set_len(max as usize);
-
-        (
-            distortion == 0,
-            indexes
-                .into_iter()
-                .zip(distances.into_iter())
-                .filter(|v| v.0 != 0)
-                .collect::<Vec<(H3Index, i32)>>(),
+    let mut indexes = Vec::<H3Index>::with_capacity(max as usize);
+    let mut distances = Vec::<HexDistance>::with_capacity(max as usize);
+    match unsafe {
+        libh3_sys::gridDiskDistancesUnsafe(
+            origin,
+            k_ring,
+            indexes.as_mut_ptr(),
+            distances.as_mut_ptr(),
         )
     }
+    .into()
+    {
+        H3Err::Success => {}
+        error => return Err(error),
+    }
+    unsafe { indexes.set_len(max as usize) };
+    unsafe { distances.set_len(max as usize) };
+
+    let result = indexes
+        .into_iter()
+        .zip(distances.into_iter())
+        .filter(|v| v.0 != 0)
+        .collect::<Vec<(H3Index, HexDistance)>>();
+    Ok(result)
 }
 
 /// Get the grid distance between two hex indexes. This function may fail
@@ -359,16 +538,14 @@ pub fn hex_range_distances(origin: H3Index, k: i32) -> (bool, Vec<(H3Index, i32)
 ///
 /// ```
 /// use libh3::h3_distance;
-/// assert_eq!(h3_distance(0x8a2a1072b4a7fff, 0x8a2a1072b58ffff), Ok(1));
+/// assert_eq!(h3_distance(0x8a2a1072b4a7fff, 0x8a2a1072b58ffff)?, 1);
+/// # Ok::<(), libh3::H3Err>(())
 /// ```
-pub fn h3_distance(origin: H3Index, end: H3Index) -> Result<i32, ()> {
-    unsafe {
-        let r = libh3_sys::h3Distance(origin, end);
-        if r < 0 {
-            Err(())
-        } else {
-            Ok(r)
-        }
+pub fn h3_distance(origin: H3Index, end: H3Index) -> Result<i64, H3Err> {
+    let mut distance = 0i64;
+    match unsafe { libh3_sys::gridDistance(origin, end, &mut distance) }.into() {
+        H3Err::Success => Ok(distance),
+        error => return Err(error),
     }
 }
 
@@ -386,107 +563,72 @@ pub fn h3_distance(origin: H3Index, end: H3Index) -> Result<i32, ()> {
 /// use libh3::{polyfill, GeoCoord, degs_to_rads};
 /// /// Some vertexes around San Francisco
 /// let sf_verts = vec![
-///   (0.659966917655, -2.1364398519396),
-///   (0.6595011102219, -2.1359434279405),
-///   (0.6583348114025, -2.1354884206045),
-///   (0.6581220034068, -2.1382437718946),
-///   (0.6594479998527, -2.1384597563896),
-///   (0.6599990002976, -2.1376771158464),
+///     (0.659966917655, -2.1364398519396),
+///     (0.6595011102219, -2.1359434279405),
+///     (0.6583348114025, -2.1354884206045),
+///     (0.6581220034068, -2.1382437718946),
+///     (0.6594479998527, -2.1384597563896),
+///     (0.6599990002976, -2.1376771158464),
 /// ]
 /// .iter()
 /// .map(|v| GeoCoord::new(v.0, v.1))
 /// .collect();
 ///
-/// let h = polyfill(&vec![sf_verts], 9);
+/// let h = polyfill(&mut [sf_verts], 9)?;
 /// assert_eq!(h.len(), 1253);
-///
-///
-/// /// Fill a polygon around Wellington, NZ
-/// /// Coordinates are in GeoJSON lon, lat order.
-///
-/// let wellington_verts: Vec<GeoCoord> = vec![
-///    (174.800937866947, -41.22501356278325),
-///    (174.8079721211159, -41.226732341115365),
-///    (174.82262997231396, -41.231639803277986),
-///    (174.83561105648377, -41.23873115217201),
-///    (174.84634815587896, -41.24769587535717),
-///    (174.85069634833735, -41.252194466801384),
-///    (174.8587207192276, -41.26264015566857),
-///    (174.8636809159909, -41.27410982273725),
-///    (174.86536017144866, -41.28610182569948),
-///    (174.8653611411562, -41.29165993179072),
-///    (174.8636858034186, -41.30364998147521),
-///    (174.85872883206798, -41.31511423541933),
-///    (174.8507068877321, -41.32555201329627),
-///    (174.846359294586, -41.33004662498431),
-///    (174.8356222320399, -41.33900220579377),
-///    (174.82263983163466, -41.346084796073406),
-///    (174.807979604528, -41.35098543989819),
-///    (174.80094378133927, -41.35270175860709),
-///    (174.78524618901284, -41.35520670405109),
-///    (174.76919781098724, -41.35520670405109),
-///    (174.75350021866086, -41.35270175860712),
-///    (174.7464643954721, -41.35098543989822),
-///    (174.7318041683653, -41.346084796073406),
-///    (174.71882176795995, -41.33900220579369),
-///    (174.7080847054138, -41.330046624984135),
-///    (174.70373711226773, -41.32555201329609),
-///    (174.69571516793187, -41.31511423541913),
-///    (174.69075819658127, -41.303649981474955),
-///    (174.68908285884382, -41.29165993179046),
-///    (174.68908382855136, -41.2861018256992),
-///    (174.69076308400918, -41.274109822737074),
-///    (174.69572328077246, -41.26264015566849),
-///    (174.70374765166264, -41.252194466801384),
-///    (174.70809584412103, -41.24769587535717),
-///    (174.71883294351622, -41.23873115217201),
-///    (174.731814027686, -41.231639803278014),
-///    (174.746471878884, -41.22673234111539),
-///    (174.75350613305287, -41.22501356278328),
-///    (174.7691998725514, -41.222504896122565),
-///    (174.78524412744844, -41.222504896122565),
-///    (174.800937866947, -41.22501356278325),
-/// ].iter().map(|v| GeoCoord::new(degs_to_rads(v.1), degs_to_rads(v.0))).collect();
-///
-/// let mut h = polyfill(&vec![wellington_verts], 6);
-/// assert_eq!(h.len(), 5);
-/// h.sort_unstable();
-/// assert_eq!(h, vec![606774924341673983, 606774925281198079, 606774925549633535, 606774929307729919, 606774929441947647]);
+/// # Ok::<(), libh3::H3Err>(())
 /// ```
-pub fn polyfill(polygon: &[Vec<GeoCoord>], resolution: Resolution) -> Vec<H3Index> {
-    let real_polygon = polygon
+pub fn polyfill(
+    polygon: &mut [Vec<GeoCoord>],
+    resolution: Resolution,
+) -> Result<Vec<H3Index>, H3Err> {
+    let mut real_polygon = polygon
         .iter()
-        .map(|p| p.iter().map(libh3_sys::GeoCoord::from).collect())
-        .collect::<Vec<Vec<libh3_sys::GeoCoord>>>();
+        .map(|p| p.iter().map(libh3_sys::LatLng::from).collect())
+        .collect::<Vec<Vec<libh3_sys::LatLng>>>();
 
-    unsafe {
-        let fence = libh3_sys::Geofence {
-            numVerts: real_polygon[0].len() as i32,
-            verts: real_polygon[0].as_ptr(),
-        };
+    let fence = libh3_sys::GeoLoop {
+        numVerts: real_polygon[0].len() as i32,
+        verts: real_polygon[0].as_mut_ptr(),
+    };
 
-        let holes = real_polygon
-            .iter()
-            .skip(1)
-            .map(|p| libh3_sys::Geofence {
-                numVerts: p.len() as i32,
-                verts: p.as_ptr(),
-            })
-            .collect::<Vec<libh3_sys::Geofence>>();
+    let mut holes = real_polygon
+        .iter()
+        .skip(1)
+        .map(|p| libh3_sys::GeoLoop {
+            numVerts: p.len() as i32,
+            verts: &mut p[0].to_owned(),
+        })
+        .collect::<Vec<libh3_sys::GeoLoop>>();
 
-        let p = libh3_sys::GeoPolygon {
-            geofence: fence,
-            numHoles: (real_polygon.len() - 1) as i32,
-            holes: holes.as_ptr(),
-        };
+    let p = libh3_sys::GeoPolygon {
+        geoloop: fence,
+        numHoles: (real_polygon.len() - 1) as i32,
+        holes: holes.as_mut_ptr(),
+    };
 
-        let max = libh3_sys::maxPolyfillSize(&p, resolution as i32);
-        let mut r = Vec::<H3Index>::with_capacity(max as usize);
-        libh3_sys::polyfill(&p, resolution as i32, r.as_mut_ptr());
-        r.set_len(max as usize);
-        r.retain(|&v| v != 0);
-        r
+    let mut max = 0i64;
+    match unsafe {
+        libh3_sys::maxPolygonToCellsSizeExperimental(&p, resolution as i32, 0, &mut max)
     }
+    .into()
+    {
+        H3Err::Success => {}
+        error => return Err(error),
+    }
+
+    let mut r = Vec::<H3Index>::with_capacity(max as usize);
+    match unsafe {
+        libh3_sys::polygonToCellsExperimental(&p, resolution as i32, 0, max, r.as_mut_ptr())
+    }
+    .into()
+    {
+        H3Err::Success => {}
+        error => return Err(error),
+    }
+    unsafe { r.set_len(max as usize) };
+    r.retain(|&v| v != 0);
+    Ok(r)
 }
 
 /// Returns the size of the array needed by h3ToChildren for these inputs.
@@ -498,10 +640,15 @@ pub fn polyfill(polygon: &[Vec<GeoCoord>], resolution: Resolution) -> Vec<H3Inde
 ///
 /// ```
 /// use libh3::max_h3_to_children_size;
-/// assert_eq!(max_h3_to_children_size(0x852a1073fffffff, 6), 7);
+/// assert_eq!(max_h3_to_children_size(0x852a1073fffffff, 6)?, 7);
+/// # Ok::<(), libh3::H3Err>(())
 /// ```
-pub fn max_h3_to_children_size(h: H3Index, resolution: Resolution) -> i32 {
-    unsafe { libh3_sys::maxH3ToChildrenSize(h, resolution as i32) }
+pub fn max_h3_to_children_size(h: H3Index, resolution: Resolution) -> Result<i64, H3Err> {
+    let mut out = 0i64;
+    match unsafe { libh3_sys::cellToChildrenSize(h, resolution as i32, &mut out) }.into() {
+        H3Err::Success => Ok(out),
+        error => Err(error),
+    }
 }
 
 /// Returns the parent (coarser) index containing h3.
@@ -513,10 +660,15 @@ pub fn max_h3_to_children_size(h: H3Index, resolution: Resolution) -> i32 {
 ///
 /// ```
 /// use libh3::h3_to_parent;
-/// assert_eq!(h3_to_parent(0x8a2a1072b4a7fff, 5), 0x852a1073fffffff);
+/// assert_eq!(h3_to_parent(0x8a2a1072b4a7fff, 5)?, 0x852a1073fffffff);
+/// # Ok::<(), libh3::H3Err>(())
 /// ```
-pub fn h3_to_parent(h: H3Index, resolution: Resolution) -> H3Index {
-    unsafe { libh3_sys::h3ToParent(h, resolution as i32) }
+pub fn h3_to_parent(h: H3Index, resolution: Resolution) -> Result<H3Index, H3Err> {
+    let mut out: H3Index = 0;
+    match unsafe { libh3_sys::cellToParent(h, resolution as i32, &mut out) }.into() {
+        H3Err::Success => Ok(out),
+        error => Err(error),
+    }
 }
 
 /// Returns children indexes contained by the given index at the given resolution.
@@ -529,7 +681,7 @@ pub fn h3_to_parent(h: H3Index, resolution: Resolution) -> H3Index {
 /// ```
 /// use libh3::h3_to_children;
 /// assert_eq!(
-///     h3_to_children(0x852a1073fffffff, 6),
+///     h3_to_children(0x852a1073fffffff, 6)?,
 ///     vec![
 ///         0x862a10707ffffff,
 ///         0x862a1070fffffff,
@@ -540,15 +692,17 @@ pub fn h3_to_parent(h: H3Index, resolution: Resolution) -> H3Index {
 ///         0x862a10737ffffff
 ///     ]
 /// );
+/// # Ok::<(), libh3::H3Err>(())
 /// ```
-pub fn h3_to_children(h: H3Index, resolution: Resolution) -> Vec<H3Index> {
-    let max = max_h3_to_children_size(h, resolution) as usize;
+pub fn h3_to_children(h: H3Index, resolution: Resolution) -> Result<Vec<H3Index>, H3Err> {
+    let max = max_h3_to_children_size(h, resolution)?;
     let mut result = Vec::<H3Index>::with_capacity(max as usize);
-    unsafe {
-        libh3_sys::h3ToChildren(h, resolution as i32, result.as_mut_ptr());
-        result.set_len(max as usize);
-        result
+    match unsafe { libh3_sys::cellToChildren(h, resolution as i32, result.as_mut_ptr()) }.into() {
+        H3Err::Success => {}
+        error => return Err(error),
     }
+    unsafe { result.set_len(max as usize) };
+    Ok(result)
 }
 
 /// Number of resolution 0 H3 indexes.
@@ -556,9 +710,10 @@ pub fn h3_to_children(h: H3Index, resolution: Resolution) -> Vec<H3Index> {
 /// ```
 /// use libh3::res_0_index_count;
 /// assert_eq!(res_0_index_count(), 122);
+/// # Ok::<(), libh3::H3Err>(())
 /// ```
 pub fn res_0_index_count() -> i32 {
-    unsafe { libh3_sys::res0IndexCount() }
+    unsafe { libh3_sys::res0CellCount() }
 }
 
 /// All the resolution 0 H3 indexes.
@@ -566,16 +721,106 @@ pub fn res_0_index_count() -> i32 {
 /// ```
 /// use libh3::get_res_0_indexes;
 /// assert_eq!(
-///     get_res_0_indexes().len(),
+///     get_res_0_indexes()?.len(),
 ///     122
 /// );
+/// # Ok::<(), libh3::H3Err>(())
 /// ```
-pub fn get_res_0_indexes() -> Vec<H3Index> {
+pub fn get_res_0_indexes() -> Result<Vec<H3Index>, H3Err> {
     let max = res_0_index_count() as usize;
     let mut result = Vec::<H3Index>::with_capacity(max as usize);
-    unsafe {
-        libh3_sys::getRes0Indexes(result.as_mut_ptr());
-        result.set_len(max);
-        result
+    match unsafe { libh3_sys::getRes0Cells(result.as_mut_ptr()) }.into() {
+        H3Err::Success => {}
+        error => return Err(error),
+    }
+    unsafe { result.set_len(max) };
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_libh3() -> Result<(), H3Err> {
+        // Some vertexes around San Francisco
+        let sf_verts = vec![
+            (0.659966917655, -2.1364398519396),
+            (0.6595011102219, -2.1359434279405),
+            (0.6583348114025, -2.1354884206045),
+            (0.6581220034068, -2.1382437718946),
+            (0.6594479998527, -2.1384597563896),
+            (0.6599990002976, -2.1376771158464),
+        ]
+        .iter()
+        .map(|v| GeoCoord::new(v.0, v.1))
+        .collect();
+
+        let h = polyfill(&mut [sf_verts], 9)?;
+        assert_eq!(h.len(), 1253);
+
+        // Fill a polygon around Wellington, NZ
+        // Coordinates are in GeoJSON lng, lat order.
+        let wellington_verts: Vec<GeoCoord> = vec![
+            (174.800937866947, -41.22501356278325),
+            (174.8079721211159, -41.226732341115365),
+            (174.82262997231396, -41.231639803277986),
+            (174.83561105648377, -41.23873115217201),
+            (174.84634815587896, -41.24769587535717),
+            (174.85069634833735, -41.252194466801384),
+            (174.8587207192276, -41.26264015566857),
+            (174.8636809159909, -41.27410982273725),
+            (174.86536017144866, -41.28610182569948),
+            (174.8653611411562, -41.29165993179072),
+            (174.8636858034186, -41.30364998147521),
+            (174.85872883206798, -41.31511423541933),
+            (174.8507068877321, -41.32555201329627),
+            (174.846359294586, -41.33004662498431),
+            (174.8356222320399, -41.33900220579377),
+            (174.82263983163466, -41.346084796073406),
+            (174.807979604528, -41.35098543989819),
+            (174.80094378133927, -41.35270175860709),
+            (174.78524618901284, -41.35520670405109),
+            (174.76919781098724, -41.35520670405109),
+            (174.75350021866086, -41.35270175860712),
+            (174.7464643954721, -41.35098543989822),
+            (174.7318041683653, -41.346084796073406),
+            (174.71882176795995, -41.33900220579369),
+            (174.7080847054138, -41.330046624984135),
+            (174.70373711226773, -41.32555201329609),
+            (174.69571516793187, -41.31511423541913),
+            (174.69075819658127, -41.303649981474955),
+            (174.68908285884382, -41.29165993179046),
+            (174.68908382855136, -41.2861018256992),
+            (174.69076308400918, -41.274109822737074),
+            (174.69572328077246, -41.26264015566849),
+            (174.70374765166264, -41.252194466801384),
+            (174.70809584412103, -41.24769587535717),
+            (174.71883294351622, -41.23873115217201),
+            (174.731814027686, -41.231639803278014),
+            (174.746471878884, -41.22673234111539),
+            (174.75350613305287, -41.22501356278328),
+            (174.7691998725514, -41.222504896122565),
+            (174.78524412744844, -41.222504896122565),
+            (174.800937866947, -41.22501356278325),
+        ]
+        .iter()
+        .map(|v| GeoCoord::new(degs_to_rads(v.1), degs_to_rads(v.0)))
+        .collect();
+
+        let mut h = polyfill(&mut [wellington_verts], 6)?;
+        assert_eq!(h.len(), 5);
+        h.sort_unstable();
+        assert_eq!(
+            h,
+            vec![
+                606774924341673983,
+                606774925281198079,
+                606774925549633535,
+                606774929307729919,
+                606774929441947647
+            ]
+        );
+        Ok(())
     }
 }


### PR DESCRIPTION
closes rustyconover/libh3#4

Update h3 to 4.2.1
Add [features] default = ["uber_h3_from_scratch"]; Adopted Documentation; Download and build Uber's h3-lib; fixed some vector bugs and cargo clippy hints